### PR TITLE
Allow creation of branches for linear versions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -43,6 +43,10 @@ Powered by:
 ```
 Usage: gradlew run --args="[Options]"
 Options:
+      --create-version-branches 
+                             Creates a separate branch for each version,
+                               including linear versions. This may be useful 
+                               for quickly switching between multiple versions.   
       --exclude-version[=<version>[,<version>]...]
                              Specify version(s) to exclude from decompilation.
                                The exclusion info will be added to the

--- a/src/main/groovy/com/github/winplay02/gitcraft/GitCraftCli.groovy
+++ b/src/main/groovy/com/github/winplay02/gitcraft/GitCraftCli.groovy
@@ -49,6 +49,7 @@ class GitCraftCli {
 		cli_args._(longOpt: 'only-snapshot', 'Only decompiles snapshots (includes pending and non-linear, if not otherwise specified).');
 		cli_args._(longOpt: 'override-repo-target', args: 1, argName: 'path', type: Path,
 			'Changes the location of the target repository, as repo names may get quite long and unintuitive. If not used carefully, this can lead to repositories with unwanted mixed mappings or straight up refuse to work as some versions in the target repository may be missing.');
+        cli_args._(longOpt: 'create-version-branches', 'Creates a separate branch for each version, including linear versions. This may be useful for quickly switching between multiple versions.')
 		cli_args.h(longOpt: 'help', 'Displays this help screen');
 		return cli_args;
 	}
@@ -66,6 +67,7 @@ class GitCraftCli {
 		config.readableNbt = !cli_args_parsed.hasOption("no-datagen-snbt");
 		config.loadDatagenRegistry = !cli_args_parsed.hasOption("no-datagen-report");
 		config.refreshDecompilation = cli_args_parsed.hasOption("refresh");
+        config.createVersionBranches = cli_args_parsed.hasOption("create-version-branches");
 		if (cli_args_parsed.hasOption("help")) {
 			cli_args.usage();
 			return null;

--- a/src/main/groovy/com/github/winplay02/gitcraft/GitCraftConfig.java
+++ b/src/main/groovy/com/github/winplay02/gitcraft/GitCraftConfig.java
@@ -40,6 +40,7 @@ public class GitCraftConfig {
 	public String gitUser = "Mojang";
 	public String gitMail = "gitcraft@decompiled.mc";
 	public String gitMainlineLinearBranch = "master";
+    public boolean createVersionBranches = false;
 
 	/// Refresh settings
 	public boolean refreshDecompilation = false;
@@ -164,6 +165,9 @@ public class GitCraftConfig {
 		if (overrideRepositoryPath != null) {
 			MiscHelper.println("Repository path is overridden. This may lead to various errors (see help). Proceed with caution. Target: %s", overrideRepositoryPath);
 		}
+        if (createVersionBranches) {
+            MiscHelper.println("A seperate branch will be created for each version.");
+        }
 	}
 
 	public boolean isOnlyVersion() {


### PR DESCRIPTION
This adds the cli arg `--create-version-branches` which will create separate branches for each version, even linear versions. I personally find this useful for my workflow as it is much easier in many IDEs to switch to a branch than it is to checkout a specific commit. This is false by default.