### PR TITLE
Update step dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,11 @@ repositories {
 	mavenCentral()
 }
 
+java {
+	sourceCompatibility = JavaVersion.VERSION_24
+	targetCompatibility = JavaVersion.VERSION_24
+}
+
 tasks.withType(JavaCompile).configureEach {
 	it.options.encoding = "UTF-8"
 	it.options.release = 24
@@ -43,10 +48,7 @@ tasks.register("runLauncher", JavaExec) {
 	group = ApplicationPlugin.APPLICATION_GROUP
 	classpath = sourceSets.main.runtimeClasspath
 	mainClass = 'com.github.winplay02.gitcraft.launcher.GitCraftLauncher'
-	environment("GITCRAFT_LAUNCH_AGENT", tasks.getByPath(":launcher_agent:jar").archiveFile.get().getAsFile().getAbsolutePath())
 }
-
-runLauncher.dependsOn(":launcher_agent:jar")
 
 dependencies {
 	implementation sourceSets.lib.output

--- a/launcher_agent/build.gradle
+++ b/launcher_agent/build.gradle
@@ -1,5 +1,13 @@
-plugins {
-	id 'java'
+apply plugin: 'java'
+
+java {
+	sourceCompatibility = JavaVersion.VERSION_24
+	targetCompatibility = JavaVersion.VERSION_24
+}
+
+tasks.withType(JavaCompile).configureEach {
+	it.options.encoding = "UTF-8"
+	it.options.release = 24
 }
 
 jar {
@@ -15,5 +23,10 @@ jar {
 }
 
 jar.dependsOn(configurations.runtimeClasspath)
+
+project(':').runLauncher {
+	dependsOn jar
+	environment("GITCRAFT_LAUNCH_AGENT", jar.archiveFile.get().getAsFile().getAbsolutePath())
+}
 
 dependencies {}

--- a/src/lib/java/com/github/winplay02/gitcraft/pipeline/DependencyRelation.java
+++ b/src/lib/java/com/github/winplay02/gitcraft/pipeline/DependencyRelation.java
@@ -1,6 +1,6 @@
 package com.github.winplay02.gitcraft.pipeline;
 
-public enum DependencyType {
+public enum DependencyRelation {
 
 	/**
 	 * does not depend on the step at all

--- a/src/lib/java/com/github/winplay02/gitcraft/pipeline/ExecutionScope.java
+++ b/src/lib/java/com/github/winplay02/gitcraft/pipeline/ExecutionScope.java
@@ -1,0 +1,20 @@
+package com.github.winplay02.gitcraft.pipeline;
+
+public enum ExecutionScope {
+
+	/**
+	 * Execution is limited to one instance per node within a version graph.
+	 */
+	VERSION,
+
+	/**
+	 * Execution is limited to one instance per branch within a version graph.
+	 */
+	BRANCH,
+
+	/**
+	 * Execution is limited to one instance per version graph.
+	 */
+	GRAPH
+
+}

--- a/src/lib/java/com/github/winplay02/gitcraft/pipeline/ExecutionScope.java
+++ b/src/lib/java/com/github/winplay02/gitcraft/pipeline/ExecutionScope.java
@@ -15,6 +15,9 @@ public enum ExecutionScope {
 	/**
 	 * Execution is limited to one instance per version graph.
 	 */
-	GRAPH
+	GRAPH;
 
+	public boolean coversMultipleVersions() {
+		return this.ordinal() > VERSION.ordinal();
+	}
 }

--- a/src/main/groovy/com/github/winplay02/gitcraft/manifest/BaseMetadataProvider.java
+++ b/src/main/groovy/com/github/winplay02/gitcraft/manifest/BaseMetadataProvider.java
@@ -20,7 +20,6 @@ import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -205,7 +204,7 @@ public abstract class BaseMetadataProvider<M extends VersionsManifest<E>, E exte
 		return status.thenApply($ -> {
 			try {
 				return this.loadVersionMetadata(filePath, metadataClass, fileName);
-			} catch (IOException e) {
+			} catch (Exception e) {
 				MiscHelper.panicBecause(e, "Error while fetching version metadata");
 			}
 			return null;
@@ -224,7 +223,7 @@ public abstract class BaseMetadataProvider<M extends VersionsManifest<E>, E exte
 		return status.thenApply($ -> {
 			try {
 				return this.loadVersionMetadata(filePath, metadataClass, filePath.getFileName().toString());
-			} catch (IOException e) {
+			} catch (Exception e) {
 				MiscHelper.panicBecause(e, "Error while fetching version metadata");
 			}
 			return null;

--- a/src/main/groovy/com/github/winplay02/gitcraft/pipeline/Pipeline.java
+++ b/src/main/groovy/com/github/winplay02/gitcraft/pipeline/Pipeline.java
@@ -296,7 +296,7 @@ public class Pipeline<T extends AbstractVersion<T>> {
 		}
 		if (!executionPlan.failedTasks().isEmpty()) {
 			executionPlan.failedTasks().forEach((key, value) -> {
-				MiscHelper.println("Step %s for version %s failed: %s", key.step(), key.version(), value);
+				MiscHelper.println("Step %s for version %s failed: %s", key.step().getName(), key.version().friendlyVersion(), value);
 				value.printStackTrace();
 			});
 			MiscHelper.panic("Execution failed, for more information see trace(s) above");

--- a/src/main/groovy/com/github/winplay02/gitcraft/pipeline/Pipeline.java
+++ b/src/main/groovy/com/github/winplay02/gitcraft/pipeline/Pipeline.java
@@ -209,6 +209,10 @@ public class Pipeline<T extends AbstractVersion<T>> {
 		}
 
 		private void runSingleTask(ExecutorService executor, TupleVersionStep<T> task, Pipeline<T> pipeline, RepoWrapper repository, AbstractVersionGraph<T> versionGraph) {
+			if (executor.isShutdown()) {
+				return;
+			}
+
 			executor.execute(() -> {
 				synchronized (executionLock) {
 					if (executingTasks.contains(task) || completedTasks.contains(task)) {

--- a/src/main/groovy/com/github/winplay02/gitcraft/pipeline/Step.java
+++ b/src/main/groovy/com/github/winplay02/gitcraft/pipeline/Step.java
@@ -30,7 +30,7 @@ import java.util.function.Function;
 
 public enum Step {
 
-	RESET("Reset", Resetter::new),
+	RESET("Reset", ExecutionScope.GRAPH, Resetter::new),
 	FETCH_ARTIFACTS("Fetch Artifacts", ArtifactsFetcher::new),
 	FETCH_LIBRARIES("Fetch Libraries", LibrariesFetcher::new),
 	FETCH_ASSETS("Fetch Assets", AssetsFetcher::new),
@@ -50,23 +50,33 @@ public enum Step {
 	PROVIDE_NESTS("Provide Nests", NestsProvider::new),
 	APPLY_NESTS("Apply Nests", JarsNester::new),
 	PREEN_JARS("Preen Jars", Preener::new),
-	DECOMPILE_JARS("Decompile Jars", Decompiler::new),
-	COMMIT("Commit to repository", Committer::new),
-	REPO_GARBAGE_COLLECTOR("GC repository", RepoGarbageCollector::new),
+	DECOMPILE_JARS("Decompile Jars", ExecutionScope.GRAPH, Decompiler::new),
+	COMMIT("Commit to repository", ExecutionScope.GRAPH, Committer::new),
+	REPO_GARBAGE_COLLECTOR("GC repository", ExecutionScope.GRAPH, RepoGarbageCollector::new),
 	LAUNCH_PREPARE_HARDLINK_ASSETS("Hardlink Assets to Launch Environment", LaunchStepHardlinkAssets::new),
 	LAUNCH_PREPARE_CONSTRUCT_LAUNCHABLE_FILE("Construct a launchable file", LaunchPrepareLaunchableFile::new),
 	LAUNCH_CLIENT("Launch Client", LaunchStepLaunch::new);
 
 	private final String name;
+	private final ExecutionScope scope;
 	private final Function<StepWorker.Config, StepWorker<?, ?>> workerFactory;
 
 	Step(String name, Function<StepWorker.Config, StepWorker<?, ?>> workerFactory) {
+		this(name, ExecutionScope.VERSION, workerFactory);
+	}
+
+	Step(String name, ExecutionScope scope, Function<StepWorker.Config, StepWorker<?, ?>> workerFactory) {
 		this.name = name;
+		this.scope = scope;
 		this.workerFactory = workerFactory;
 	}
 
 	public String getName() {
 		return name;
+	}
+
+	public ExecutionScope getScope() {
+		return scope;
 	}
 
 	public StepWorker<?, ?> createWorker(StepWorker.Config config) {

--- a/src/main/groovy/com/github/winplay02/gitcraft/pipeline/StepDependencies.java
+++ b/src/main/groovy/com/github/winplay02/gitcraft/pipeline/StepDependencies.java
@@ -35,10 +35,6 @@ public record StepDependencies(Set<StepDependency> dependencies) implements Iter
 		return new StepDependencies(dst);
 	}
 
-	public void validate() {
-		// TODO
-	}
-
 	public List<Step> steps() {
 		return dependencies.stream().map(StepDependency::step).toList();
 	}

--- a/src/main/groovy/com/github/winplay02/gitcraft/pipeline/StepDependencies.java
+++ b/src/main/groovy/com/github/winplay02/gitcraft/pipeline/StepDependencies.java
@@ -1,0 +1,58 @@
+package com.github.winplay02.gitcraft.pipeline;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public record StepDependencies(Set<StepDependency> dependencies) implements Iterable<StepDependency> {
+
+	public static final StepDependencies EMPTY = new StepDependencies(Collections.emptySet());
+
+	public static StepDependencies required(Step... steps) {
+		return of(steps, DependencyRelation.REQUIRED);
+	}
+
+	public static StepDependencies notRequired(Step... steps) {
+		return of(steps, DependencyRelation.NOT_REQUIRED);
+	}
+
+	public static StepDependencies of(Step[] steps, DependencyRelation relation) {
+		return of(List.of(steps), relation);
+	}
+
+	public static StepDependencies of(List<Step> steps, DependencyRelation relation) {
+		return new StepDependencies(steps.stream().map(step -> new StepDependency(step, relation)).collect(Collectors.toSet()));
+	}
+
+	public static StepDependencies merge(StepDependencies... dependencies) {
+		Set<StepDependency> dst = new HashSet<>();
+		for (StepDependencies deps : dependencies) {
+			dst.addAll(deps.dependencies);
+		}
+		return new StepDependencies(dst);
+	}
+
+	public void validate() {
+		// TODO
+	}
+
+	public List<Step> steps() {
+		return dependencies.stream().map(StepDependency::step).toList();
+	}
+
+	public StepDependencies filterRelation(DependencyRelation relation) {
+		return new StepDependencies(dependencies.stream().filter(dep -> dep.relation() == relation).collect(Collectors.toSet()));
+	}
+
+	public DependencyRelation getRelation(Step step) {
+		return dependencies.stream().filter(dep -> dep.step() == step).map(StepDependency::relation).findAny().orElse(DependencyRelation.NONE);
+	}
+
+	@Override
+	public Iterator<StepDependency> iterator() {
+		return dependencies.iterator();
+	}
+}

--- a/src/main/groovy/com/github/winplay02/gitcraft/pipeline/StepDependency.java
+++ b/src/main/groovy/com/github/winplay02/gitcraft/pipeline/StepDependency.java
@@ -1,46 +1,4 @@
 package com.github.winplay02.gitcraft.pipeline;
 
-import com.github.winplay02.gitcraft.util.MiscHelper;
-
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-
-public record StepDependency(Map<Step, DependencyType> dependencyTypes, Set<Step> interVersionDependency) {
-	public static final StepDependency EMPTY = new StepDependency(Map.of(), Set.of());
-
-	public static StepDependency ofHardIntraVersionOnly(Step... dependencies) {
-		return new StepDependency(Arrays.stream(dependencies).collect(Collectors.toMap(Function.identity(), __ -> DependencyType.REQUIRED)), Set.of());
-	}
-
-	public static StepDependency ofIntraVersion(Set<Step> requiredDependencies, Set<Step> optionalDependencies) {
-		if (!MiscHelper.calculateSetIntersection(requiredDependencies, optionalDependencies).isEmpty()) {
-			MiscHelper.panic("A dependency of a step cannot be both required an optional.");
-		}
-		Map<Step, DependencyType> dependencyTypes = requiredDependencies.stream().collect(Collectors.toMap(Function.identity(), __ -> DependencyType.REQUIRED));
-		dependencyTypes.putAll(optionalDependencies.stream().collect(Collectors.toMap(Function.identity(), __ -> DependencyType.NOT_REQUIRED)));
-		return new StepDependency(dependencyTypes, Set.of());
-	}
-
-	public static StepDependency ofInterVersion(Step... dependencies) {
-		return new StepDependency(Map.of(), Arrays.stream(dependencies).collect(Collectors.toSet()));
-	}
-
-	public static StepDependency mergeDependencies(StepDependency d1, StepDependency d2) {
-		Set<Step> intersection = MiscHelper.calculateSetIntersection(d1.dependencyTypes().keySet(), d2.dependencyTypes().keySet());
-		for (Step step : intersection) {
-			if (d1.dependencyTypes().get(step) != d2.dependencyTypes().get(step)) {
-				MiscHelper.panic("Cannot merge step dependency declarations, as they are contradictory (Step: %s, type1: %s, type2: %s).", step, d1.dependencyTypes().get(step), d2.dependencyTypes().get(step));
-			}
-		}
-		Map<Step, DependencyType> dependencyTypes = new HashMap<>(d1.dependencyTypes());
-		dependencyTypes.putAll(d2.dependencyTypes());
-		Set<Step> interVersionDependencies = new HashSet<>(d1.interVersionDependency());
-		interVersionDependencies.addAll(d2.interVersionDependency());
-		return new StepDependency(dependencyTypes, interVersionDependencies);
-	}
+public record StepDependency(Step step, DependencyRelation relation) {
 }


### PR DESCRIPTION
depends on #20 

- The distinction between "intra-version" and "inter-version" dependencies is gone. All step dependencies are "intra-version".
- It seemed to me that "inter-version" dependencies were only ever used for steps to depend on themselves across versions, i.e. to make sure only one instance would run concurrently.
- Therefore each step now has its own `ExecutionScope` - `VERSION`, `BRANCH`, OR `GRAPH`. A step's execution is always limited to one instance in its scope.
- I added this to the steps and not the pipeline description as it seemed to me to be independent of the pipeline description. For example, no more than one commit step should run concurrently, no matter what pipeline is used.

will leave as draft for now as it needs testing