### PR TITLE
(Partially) fix fallback unpicks

### DIFF
--- a/src/main/groovy/com/github/winplay02/gitcraft/GitCraftCli.groovy
+++ b/src/main/groovy/com/github/winplay02/gitcraft/GitCraftCli.groovy
@@ -153,7 +153,7 @@ class GitCraftCli {
 		}
 		UnpickFlavour[] fallbackUnpicks = null;
 		if (cli_args_parsed.hasOption("fallback-unpick")) {
-			fallbackMappings = cli_args_parsed.'fallback-unpicks';
+			fallbackUnpicks = cli_args_parsed.'fallback-unpicks';
 		}
 
 		boolean onlyStableReleases = cli_args_parsed.hasOption("only-stable");


### PR DESCRIPTION
Was this change even tested at all lol

Beyond this simple fix, `none` also isn't properly set as the default fallback, contrary to what `--help` states, so you'll get an error if you set `--unpick=yarn` without setting any fallback if yarn unpick is unavailable.

Also just getting heaps of `java.util.concurrent.RejectedExecutionException` errors...