### PR TITLE
Add 1.21.2 to missing Parchment versions

### DIFF
--- a/src/main/groovy/com/github/winplay02/gitcraft/GitCraftQuirks.java
+++ b/src/main/groovy/com/github/winplay02/gitcraft/GitCraftQuirks.java
@@ -53,5 +53,5 @@ public class GitCraftQuirks {
 	);
 
 	// There are no releases for these parchment versions (yet)
-	public static List<String> parchmentMissingVersions = List.of("1.18", "1.19", "1.19.1", "1.20", "1.20.5");
+	public static List<String> parchmentMissingVersions = List.of("1.18", "1.19", "1.19.1", "1.20", "1.20.5", "1.21.2");
 }


### PR DESCRIPTION
There are no Parchment mappings for 1.21.2 and specifying that combination causes an error instead of fallback mappings being used.